### PR TITLE
call operators before applying state change

### DIFF
--- a/examples/machinery.rest
+++ b/examples/machinery.rest
@@ -119,11 +119,11 @@ GET /dtlab-alligator/actor/machinery/three
 POST /dtlab-alligator/actor/machinery/three
 {
   "idx": 0,
-  "value": 119.161
+  "value": 123.45
 }
 
 --
-POST /dtlab-alligator/actor/machinery/two
+POST /dtlab-alligator/actor/machinery/won
 {
   "idx": 0,
   "value": 9.17


### PR DESCRIPTION
1. each operator gets to see the new telemetry and the old state before the telemetry is added to the state and before the output of the other operators is applied
2. same code to update state is used to recover state from persistence

