### PR TITLE
https://github.com/DTLaboratory/dtlab-scala-alligator/issues/105

### DIFF
--- a/examples/machinery.rest
+++ b/examples/machinery.rest
@@ -4,6 +4,8 @@ Content-Type: application/json; charset=utf-8
 --
 
 --
+GET /dtlab-alligator/type/machinery
+--
 DELETE /dtlab-alligator/type/machinery
 --
 POST /dtlab-alligator/type/machinery
@@ -17,6 +19,14 @@ POST /dtlab-alligator/type/machinery
     "hours_online",
     "minutes_online",
     "height_first_seen"
+  ]
+}
+
+--
+POST /dtlab-alligator/type/wh_monitor
+{
+  "props": [
+    "count"
   ]
 }
 
@@ -137,40 +147,44 @@ POST /dtlab-alligator/actor/machinery/one?format=pathed
 }
 
 --
-POST /dtlab-alligator/actor/machinery/three3?format=named
+POST /dtlab-alligator/actor/machinery/three?format=named
 {
   "name": "height",
-  "value": 877.6
+  "value": 877.7
 }
 
 --
 # WEBHOOK
-GET /dtlab-alligator/webhook/fleetmgr-ss
+GET /dtlab-alligator/actor/wh_monitor/statechange
+
 --
-DELETE /dtlab-alligator/webhook/fleetmgr-ss
+# WEBHOOK
+GET /dtlab-alligator/webhook/fleetmgrss
 --
-POST /dtlab-alligator/webhook/fleetmgr-ss
+DELETE /dtlab-alligator/webhook/fleetmgrss
+--
+POST /dtlab-alligator/webhook/fleetmgrss
 {
   "target": {
     "host": "localhost",
     "port": 8082,
-    "path": "/dtlab-alligator/ingest/telemetry/fleetmgr-ss",
+    "path": "/dtlab-alligator/ingest/telemetry/fleetmgrss",
     "tls": false
   },
   "dtType": "*",
   "eventType": "StateChange"
 }
 --
-GET /dtlab-alligator/webhook/fleetmgr-cr
+GET /dtlab-alligator/webhook/fleetmgrcr
 --
-DELETE /dtlab-alligator/webhook/fleetmgr-cr
+DELETE /dtlab-alligator/webhook/fleetmgrcr
 --
-POST /dtlab-alligator/webhook/fleetmgr-cr
+POST /dtlab-alligator/webhook/fleetmgrcr
 {
   "target": {
     "host": "localhost",
     "port": 8082,
-    "path": "/dtlab-alligator/ingest/telemetry/fleetmgr-cr",
+    "path": "/dtlab-alligator/ingest/telemetry/fleetmgrcr",
     "tls": false
   },
   "dtType": "*",

--- a/src/main/scala/dtlaboratory/dtlab/actors/DtPersistentActorBase.scala
+++ b/src/main/scala/dtlaboratory/dtlab/actors/DtPersistentActorBase.scala
@@ -5,9 +5,9 @@ import akka.persistence.PersistentActor
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
 import akka.persistence.query.{EventEnvelope, PersistenceQuery}
 import akka.stream.scaladsl.{Sink, Source}
-import dtlaboratory.dtlab.models.{DtStateHolder, StateChange}
-import dtlaboratory.dtlab.observe.Observer
 import dtlaboratory.dtlab.Conf._
+import dtlaboratory.dtlab.models.DtStateHolder
+import dtlaboratory.dtlab.observe.Observer
 
 import scala.concurrent.Future
 
@@ -49,7 +49,6 @@ abstract class DtPersistentActorBase[T, J]
       saveSnapshot(DtStateHolder[T](state, children, operators))
       Observer("actor_saved_state_snapshot")
     }
-    webhooks ! StateChange()
   }
 
 }

--- a/src/main/scala/dtlaboratory/dtlab/actors/DtWebhooks.scala
+++ b/src/main/scala/dtlaboratory/dtlab/actors/DtWebhooks.scala
@@ -31,11 +31,15 @@ class DtWebhooks extends DtPersistentActorBase[DtWebhookMap, DtWebHook] {
   }
 
   def handleDtEvent(ev: DtEvent, sndr: ActorRef): Unit = {
+    val evt = ev match {
+      case _: Creation => CreationEventType()
+      case _ =>  StateChangeEventType()
+    }
     dtlaboratory.dtlab.models.DtPath.applyActorRef(sndr) match {
       case Some(dtp) =>
-        val eventMsg = DtEventMsg(ev, dtp)
+        val eventMsg = DtEventMsg(ev, StateChangeEventType(), dtp)
         state.webhooks.values
-          .filter(_.eventType == ev)
+          .filter(_.eventType == evt)
           // todo: add a filter for dtpath prefix
           .foreach(wh => {
             logger.debug(s"invoking webhook ${wh.name} for $ev event")

--- a/src/main/scala/dtlaboratory/dtlab/actors/functions/PostWebhook.scala
+++ b/src/main/scala/dtlaboratory/dtlab/actors/functions/PostWebhook.scala
@@ -31,11 +31,15 @@ object PostWebhook extends JsonSupport with HttpSupport {
     http
       .singleRequest(newUri)
       .map(r => {
-        if (r.status == StatusCodes.NotFound)
-          logger.warn(
-            s"could not post webhook. remote service ${newUri.uri} reports path not found")
-        else if (r.status.isFailure())
-          logger.warn(s"could not post webhook. $r")
+        r.status match {
+          case StatusCodes.NotFound =>
+            logger.warn(
+              s"could not post webhook. remote service ${newUri.uri} reports path not found")
+          case s if s.isFailure() =>
+            logger.warn(s"could not post webhook. $r")
+          case _ =>
+            //noop
+        }
         r.status
       })
   }

--- a/src/main/scala/dtlaboratory/dtlab/actors/functions/PostWebhook.scala
+++ b/src/main/scala/dtlaboratory/dtlab/actors/functions/PostWebhook.scala
@@ -28,7 +28,16 @@ object PostWebhook extends JsonSupport with HttpSupport {
       )
     logger.debug(s"posting webhook ${webhook.name} to " + newUri)
 
-    http.singleRequest(newUri).map(_.status)
+    http
+      .singleRequest(newUri)
+      .map(r => {
+        if (r.status == StatusCodes.NotFound)
+          logger.warn(
+            s"could not post webhook. remote service ${newUri.uri} reports path not found")
+        else if (r.status.isFailure())
+          logger.warn(s"could not post webhook. $r")
+        r.status
+      })
   }
 
 }

--- a/src/main/scala/dtlaboratory/dtlab/models/JsonSupport.scala
+++ b/src/main/scala/dtlaboratory/dtlab/models/JsonSupport.scala
@@ -33,17 +33,34 @@ trait JsonSupport
     }
   }
 
+  implicit object DtEventTypeType extends JsonFormat[DtEventType] {
+    def write(tp: DtEventType): JsValue = tp match {
+      case _: CreationEventType    => JsString("Creation")
+      case _: StateChangeEventType => JsString("StateChange")
+      case _ =>
+        throw DeserializationException("Expected DtEventType")
+    }
+    def read(value: JsValue): DtEventType = {
+      value match {
+        case JsString("Creation")    => CreationEventType()
+        case JsString("StateChange") => StateChangeEventType()
+        case _ =>
+          throw DeserializationException("Expected DtEventType string")
+      }
+    }
+  }
+
   implicit object DtEventType extends JsonFormat[DtEvent] {
     def write(tp: DtEvent): JsValue = tp match {
-      case _: Creation    => JsString("Creation")
-      case _: StateChange => JsString("StateChange")
+      case _: Creation           => JsString("Creation")
+      case StateChange(newState) => newState.toJson
       case _ =>
         throw DeserializationException("Expected DtEventType")
     }
     def read(value: JsValue): DtEvent = {
       value match {
-        case JsString("Creation")    => Creation()
-        case JsString("StateChange") => StateChange()
+        case JsString("Creation") => Creation()
+        case newState: JsObject   => newState.convertTo[StateChange]
         case _ =>
           throw DeserializationException("Expected DtEventType string")
       }
@@ -137,12 +154,12 @@ trait JsonSupport
   implicit val _i18: RootJsonFormat[DeleteOperators] = jsonFormat1(
     DeleteOperators)
   implicit val _i19: RootJsonFormat[Creation] = jsonFormat0(Creation)
-  implicit val _i22: RootJsonFormat[StateChange] = jsonFormat0(StateChange)
+  implicit val _i22: RootJsonFormat[StateChange] = jsonFormat1(StateChange)
   implicit val _i23: RootJsonFormat[DtWebHookTarget] = jsonFormat5(
     DtWebHookTarget)
   implicit val _i24: RootJsonFormat[DtWebHook] = jsonFormat6(DtWebHook)
   implicit val _i25: RootJsonFormat[DtWebhookMap] = jsonFormat1(DtWebhookMap)
   implicit val _i26: RootJsonFormat[DeleteWebhook] = jsonFormat1(DeleteWebhook)
-  implicit val _i27: RootJsonFormat[DtEventMsg] = jsonFormat3(DtEventMsg)
+  implicit val _i27: RootJsonFormat[DtEventMsg] = jsonFormat4(DtEventMsg)
 
 }

--- a/src/main/scala/dtlaboratory/dtlab/models/Message.scala
+++ b/src/main/scala/dtlaboratory/dtlab/models/Message.scala
@@ -121,11 +121,16 @@ final case class DtWebHookTarget(
     clientCertificate: Option[String]
 )
 
+sealed trait DtEventType
+final case class CreationEventType() extends DtEventType
+final case class StateChangeEventType() extends DtEventType
+
 sealed trait DtEvent
 final case class Creation() extends DtEvent
-final case class StateChange() extends DtEvent
+final case class StateChange(newState: List[Telemetry]) extends DtEvent
 
 final case class DtEventMsg(event: DtEvent,
+                            eventType: DtEventType,
                             source: DtPath,
                             created: ZonedDateTime = ZonedDateTime.now())
 
@@ -134,7 +139,7 @@ final case class DtWebHook(
     target: DtWebHookTarget,
     dtPrefix: Option[DtPath],
     dtType: DtTypeName,
-    eventType: DtEvent,
+    eventType: DtEventType,
     created: Option[ZonedDateTime] = Some(ZonedDateTime.now())
 )
 

--- a/src/test/scala/dtlaboratory/dtlab/DtPathFromActorRefSpec.scala
+++ b/src/test/scala/dtlaboratory/dtlab/DtPathFromActorRefSpec.scala
@@ -60,7 +60,7 @@ class DtPathFromActorRefSpec extends AnyFlatSpec with should.Matchers with JsonS
     myDtPath should be ('defined)
     myDtPath.get.toString should be ("/mytype/myinstance")
 
-    val myEvent = DtEventMsg(Creation(), myDtPath.get)
+    val myEvent = DtEventMsg(Creation(), CreationEventType(), myDtPath.get)
     import spray.json._
     println(myEvent.toJson)
 

--- a/src/test/scala/dtlaboratory/dtlab/JsonMarshalSpec.scala
+++ b/src/test/scala/dtlaboratory/dtlab/JsonMarshalSpec.scala
@@ -1,0 +1,52 @@
+package dtlaboratory.dtlab
+
+import dtlaboratory.dtlab.models.{
+  DtEventMsg,
+  JsonSupport,
+  StateChange,
+  StateChangeEventType,
+  Telemetry
+}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers._
+import spray.json._
+
+class JsonMarshalSpec
+    extends AnyFlatSpec
+    with should.Matchers
+    with JsonSupport {
+
+  "A value" should "marshal" in {
+
+    val state = List(
+      Telemetry(idx = 0, value = 0.1),
+      Telemetry(idx = 1, value = 0.2)
+    )
+
+    val stateChangedEvent = StateChange(newState = state)
+
+    val s1: String = stateChangedEvent.toJson.prettyPrint
+    s1.toCharArray should contain('{')
+    s1.toCharArray should contain('}')
+    s1.toCharArray should contain('\n')
+    val s2: String = stateChangedEvent.toJson.compactPrint
+    s2.toCharArray should contain('{')
+    s2.toCharArray should contain('}')
+    s2.toCharArray should not contain '\n'
+
+    val json: JsValue = s1.parseJson
+    val resurrected = json.convertTo[StateChange]
+    resurrected.newState.length should be(2)
+
+    val segs = List("mytype1", "t1", "mysubtype1", "s1")
+    val dtPath = dtlaboratory.dtlab.models.DtPath(segs).get
+    val msg: DtEventMsg = DtEventMsg(event = resurrected,
+                                     source = dtPath,
+                                     eventType = StateChangeEventType())
+    val s3: String = msg.toJson.prettyPrint
+    s3.toCharArray should contain('{')
+    s3.toCharArray should contain('}')
+    s3.toCharArray should contain('\n')
+  }
+
+}

--- a/src/test/scala/dtlaboratory/dtlab/JsonMarshalSpec.scala
+++ b/src/test/scala/dtlaboratory/dtlab/JsonMarshalSpec.scala
@@ -39,14 +39,19 @@ class JsonMarshalSpec
     resurrected.newState.length should be(2)
 
     val segs = List("mytype1", "t1", "mysubtype1", "s1")
-    val dtPath = dtlaboratory.dtlab.models.DtPath(segs).get
-    val msg: DtEventMsg = DtEventMsg(event = resurrected,
-                                     source = dtPath,
-                                     eventType = StateChangeEventType())
-    val s3: String = msg.toJson.prettyPrint
-    s3.toCharArray should contain('{')
-    s3.toCharArray should contain('}')
-    s3.toCharArray should contain('\n')
+    dtlaboratory.dtlab.models.DtPath(segs) match {
+      case Some(dtPath) =>
+        val msg: DtEventMsg = DtEventMsg(event = resurrected,
+                                         source = dtPath,
+                                         eventType = StateChangeEventType())
+        val s3: String = msg.toJson.prettyPrint
+        s3.toCharArray should contain('{')
+        s3.toCharArray should contain('}')
+        s3.toCharArray should contain('\n')
+      case _ =>
+        fail()
+    }
+
   }
 
 }


### PR DESCRIPTION
webhooks have been tested with the ingest service rerouting events to monitoring actors in the same dtlab instance

https://github.com/DTLaboratory/dtlab-scala-alligator/issues/105