### PR TITLE
objectfmt

### DIFF
--- a/examples/machinery.rest
+++ b/examples/machinery.rest
@@ -1,4 +1,7 @@
 http://localhost:8081
+#https://sandbox.dtlaboratory.com
+
+#Authorization: Bearer haha
 
 Content-Type: application/json; charset=utf-8
 --
@@ -44,6 +47,11 @@ GET /dtlab-alligator/actor/machinery/two
 GET /dtlab-alligator/actor/machinery/three
 --
 GET /dtlab-alligator/actor/machinery/three?format=named
+
+--
+GET /dtlab-alligator/actor/machinery/
+--
+GET /dtlab-alligator/actor/machinery/three?format=object
 
 --
 DELETE /dtlab-alligator/actor/machinery/three/operator
@@ -128,12 +136,16 @@ GET /dtlab-alligator/actor/machinery/three?format=named
 GET /dtlab-alligator/actor/machinery/three?format=pathed
 
 --
+GET /dtlab-alligator/actor/machinery
+--
+GET /dtlab-alligator/actor/machinery/
+--
 GET /dtlab-alligator/actor/machinery/three
 --
 POST /dtlab-alligator/actor/machinery/three
 {
   "idx": 0,
-  "value": 123.46
+  "value": 123.4699
 }
 
 --

--- a/src/main/scala/dtlaboratory/dtlab/routes/functions/StateApiTrait.scala
+++ b/src/main/scala/dtlaboratory/dtlab/routes/functions/StateApiTrait.scala
@@ -78,6 +78,9 @@ trait StateApiTrait extends Directives with JsonSupport with LazyLogging {
           case Some("named") =>
             Observer("actor_route_telemetry_named")
             applyStateApiFmt(segs, namedFmt, NamedUnWrapper)
+          case Some("object") =>
+            Observer("actor_route_telemetry_object")
+            applyStateApiFmt(segs, objFmt, NamedUnWrapper) // TODO: make for obj or make it unsupported
           case _ =>
             Observer("actor_route_telemetry_idx")
             applyStateApiFmt(segs, indexedFmt, IdxUnWrapper)

--- a/src/main/scala/dtlaboratory/dtlab/routes/functions/TelemetryUnWrappers.scala
+++ b/src/main/scala/dtlaboratory/dtlab/routes/functions/TelemetryUnWrappers.scala
@@ -36,19 +36,19 @@ object TelemetryUnWrappers
 
   def NamedUnWrapper(dtp: DtPath): Route = {
     entity(as[NamedTelemetry]) { ltelem =>
-      {
-        val ntelem = ltelem.copy(datetime = Some(java.time.ZonedDateTime.now()))
-        onSuccess(NamedUnMarshaller(Some(ntelem), dtp)) {
-          case Some(telemetry: Telemetry) =>
-            applyTelemetryMsg(dtp, telemetry)
-          case _ =>
-            logger.warn(s"can not unmarshall telemetry")
-            complete(
-              StatusCodes.BadRequest,
-              s"Can not validate - please check that type definition '${dtp
-                .endTypeName()}' exists and supports property '${ntelem.name}'.")
-        }
+    {
+      val ntelem = ltelem.copy(datetime = Some(java.time.ZonedDateTime.now()))
+      onSuccess(NamedUnMarshaller(Some(ntelem), dtp)) {
+        case Some(telemetry: Telemetry) =>
+          applyTelemetryMsg(dtp, telemetry)
+        case _ =>
+          logger.warn(s"can not unmarshall telemetry")
+          complete(
+            StatusCodes.BadRequest,
+            s"Can not validate - please check that type definition '${dtp
+              .endTypeName()}' exists and supports property '${ntelem.name}'.")
       }
+    }
     }
   }
 


### PR DESCRIPTION
new query param `format=object` on GET to make it easier for integration that doesn't care about telemetry